### PR TITLE
bug28844 Relax bootstrap percentage regex

### DIFF
--- a/stem/process.py
+++ b/stem/process.py
@@ -138,7 +138,7 @@ def launch_tor(tor_cmd = 'tor', args = None, torrc_path = None, completion_perce
       signal.signal(signal.SIGALRM, timeout_handler)
       signal.setitimer(signal.ITIMER_REAL, timeout)
 
-    bootstrap_line = re.compile('Bootstrapped ([0-9]+)%: ')
+    bootstrap_line = re.compile('Bootstrapped ([0-9]+)%')
     problem_line = re.compile('\[(warn|err)\] (.*)$')
     last_problem = 'Timed out'
 


### PR DESCRIPTION
After integrating #28731 in tor, the bootstrap percentage regex no
longer matches.  Relax it accordingly.