### PR TITLE
Fix linux_distribution call in python3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyflakes
 pycodestyle
 tox
 cryptography
+distro

--- a/test/task.py
+++ b/test/task.py
@@ -30,6 +30,7 @@ import re
 import sys
 import time
 import traceback
+import distro
 
 import stem
 import stem.prereq
@@ -119,7 +120,7 @@ def _check_platform_version():
   elif platform.system() == 'Darwin':
     extra = platform.release()
   elif platform.system() == 'Linux':
-    extra = ' '.join(platform.linux_distribution()[:2])
+    extra = ' '.join(distro.linux_distribution(full_distribution_name=False)[:2])
   else:
     extra = None
 


### PR DESCRIPTION
In Python3.8, the method platform.linux_distribution is deprecated and
removed. The alternative is to use the module distro, which has been
built to replace this function.

This commit adds the module in the requirements and changes the call.