### PR TITLE
Update links in tutorials

### DIFF
--- a/docs/tutorials/east_of_the_sun.rst
+++ b/docs/tutorials/east_of_the_sun.rst
@@ -73,8 +73,7 @@ function provides an easy method for accessing this information, with a few
 caveats...
 
 * Connection resolvers are platform specific. We `support several
-  <../api/util/connection.html#stem.util.connection.Resolver>`_ but not not
-  all, most notably Windows (:trac:`9850`).
+  <../api/util/connection.html#stem.util.connection.Resolver>`_ platforms but not all.
 
 * By default Tor runs with a feature called **DisableDebuggerAttachment**. This
   prevents debugging applications like gdb from analyzing Tor unless it is run

--- a/docs/tutorials/mirror_mirror_on_the_wall.rst
+++ b/docs/tutorials/mirror_mirror_on_the_wall.rst
@@ -80,7 +80,7 @@ easy as...
 
 **Please remember that Tor is a shared resource!** If you're going to
 contribute much load please consider `running a relay
-<https://www.torproject.org/docs/tor-doc-relay.html.en>`_ to offset your use.
+<https://community.torproject.org/relay/>`_ to offset your use.
 
 **ORPorts** communicate through the `tor protocol
 <https://gitweb.torproject.org/torspec.git/tree/tor-spec.txt>`_, and can be
@@ -144,7 +144,7 @@ against Tor you may want to set some of the following in your `torrc
 <https://www.torproject.org/docs/faq.html.en#torrc>`_. Keep in mind that these
 add a small burden to the network, so don't set them in a widely distributed
 application. And, of course, please consider `running Tor as a relay
-<https://www.torproject.org/docs/tor-doc-relay.html.en>`_ so you give back to
+<https://community.torproject.org/relay/>`_ so you give back to
 the network!
 
 .. code-block:: lighttpd

--- a/docs/tutorials/the_little_relay_that_could.rst
+++ b/docs/tutorials/the_little_relay_that_could.rst
@@ -2,7 +2,7 @@ The Little Relay that Could
 ===========================
 
 Let's say you just set up your very first `Tor relay
-<https://www.torproject.org/docs/tor-doc-relay.html.en>`_ (thank you!), and now
+<https://community.torproject.org/relay/>`_ (thank you!), and now
 you want to write a script that tells you how much it is being used.
 
 First, for any script to talk with your relay it will need to have a control


### PR DESCRIPTION
I noticed that a few places could be updated in the tutorials since:
- the documentation for running Tor relays has moved to a new URL and the old site is no longer updated, and
- [Trac ticket 9850](https://trac.torproject.org/9850) has been closed.

I made these updates in this commit.  Please take a look.  Thank you!