### PR TITLE
test/integ/process.py: Detect Tor exiting with nonzero exitcode

### DIFF
--- a/test/integ/process.py
+++ b/test/integ/process.py
@@ -591,8 +591,14 @@ class TestProcess(unittest.TestCase):
       start_time = time.time()
 
       while time.time() - start_time < 30:
-        if tor_process.poll() == 0:
-          return  # tor exited
+        if tor_process.poll() != None:
+          exitcode = tor_process.returncode
+          if exitcode < 0:
+            raise AssertionError("Tor exited with signal %d"%-exitcode)
+          elif exitcode > 0:
+            raise AssertionError("Tor exited with exit code %d"%exitcode)
+          else:
+            return  # tor exited without error.
 
         time.sleep(0.01)
 
@@ -632,8 +638,14 @@ class TestProcess(unittest.TestCase):
       start_time = time.time()
 
       while time.time() - start_time < 20:
-        if tor_process.poll() == 0:
-          return  # tor exited
+        if tor_process.poll() != None:
+          exitcode = tor_process.returncode
+          if exitcode < 0:
+            raise AssertionError("Tor exited with signal %d"%-exitcode)
+          elif exitcode > 0:
+            raise AssertionError("Tor exited with exit code %d"%exitcode)
+          else:
+            return  # tor exited without error.
 
         time.sleep(0.01)
 


### PR DESCRIPTION
The take_ownership_via_{pid,controller} tests previously used
"tor_process_poll() == 0" to see whether Tor had existed.  This
caused a misleading test failure in the case where Tor exited
because of a signal, or returned a nonzero exit code: the tests
would report that Tor had not exited at all.