### PR TITLE
Encode object before hashing

### DIFF
--- a/stem/descriptor/collector.py
+++ b/stem/descriptor/collector.py
@@ -326,7 +326,7 @@ class File(object):
     if os.path.exists(path):
       with open(path) as prior_file:
         expected_hash = binascii.hexlify(base64.b64decode(self.sha256))
-        actual_hash = hashlib.sha256(prior_file.read()).hexdigest()
+        actual_hash = hashlib.sha256(prior_file.read().encode('utf-8')).hexdigest().encode('utf-8')
 
         if expected_hash == actual_hash:
           return path  # nothing to do, we already have the file


### PR DESCRIPTION
When parsing cached files the following exception is raised:
`TypeError: Unicode-objects must be encoded before hashing`

Encoding before hashing solve this issue.

This patch fails for python < 3.6 (https://travis-ci.org/github/juga0/stem/builds/676610639), so it needs to be modified to support those versions.