### PR TITLE
Adds support for ONION_CLIENT_AUTH_ADD, ONION_CLIENT_AUTH_REMOVE and ONION_CLIENT_AUTH_VIEW

### DIFF
--- a/stem/interpreter/settings.cfg
+++ b/stem/interpreter/settings.cfg
@@ -87,6 +87,9 @@ help.general
 |  CLOSESTREAM - closes the given stream
 |  ADD_ONION - create a new hidden service
 |  DEL_ONION - delete a hidden service that was created with ADD_ONION
+|  ONION_CLIENT_AUTH_ADD - add Client Authentication for a v3 onion service
+|  ONION_CLIENT_AUTH_REMOVE - remove Client Authentication for a v3 onion service
+|  ONION_CLIENT_AUTH_VIEW - view Client Authentication for a v3 onion service
 |  HSFETCH - retrieve a hidden service descriptor, providing it in a HS_DESC_CONTENT event
 |  HSPOST - uploads a hidden service descriptor
 |  RESOLVE - issues an asynchronous dns or rdns request over tor
@@ -122,6 +125,9 @@ help.usage REDIRECTSTREAM => REDIRECTSTREAM StreamID Address [Port]
 help.usage CLOSESTREAM => CLOSESTREAM StreamID Reason [Flag]
 help.usage ADD_ONION => KeyType:KeyBlob [Flags=Flag] (Port=Port [,Target])...
 help.usage DEL_ONION => ServiceID
+help.usage ONION_CLIENT_AUTH_ADD => ServiceID KeyType PrivateKeyBlob [ClientName] [Permanent]
+help.usage ONION_CLIENT_AUTH_REMOVE => ServiceID
+help.usage ONION_CLIENT_AUTH_VIEW => ServiceID
 help.usage HSFETCH => HSFETCH (HSAddress/v2-DescId) [SERVER=Server]...
 help.usage HSPOST => [SERVER=Server] DESCRIPTOR
 help.usage RESOLVE => RESOLVE [mode=reverse] address
@@ -264,6 +270,9 @@ help.description.add_onion
 help.description.del_onion
 |Delete a hidden service that was created with ADD_ONION.
 
+help.description.onion_client_auth
+|Add, remove or view Client Authentication for a v3 onion service.
+
 help.description.hsfetch
 |Retrieves the descriptor for a hidden service. This is an asynchronous
 |request, with the descriptor provided by a HS_DESC_CONTENT event.
@@ -326,6 +335,9 @@ autocomplete ADD_ONION NEW:RSA1024
 autocomplete ADD_ONION NEW:ED25519-V3
 autocomplete ADD_ONION RSA1024:
 autocomplete ADD_ONION ED25519-V3:
+autocomplete ONION_CLIENT_AUTH_ADD
+autocomplete ONION_CLIENT_AUTH_REMOVE
+autocomplete ONION_CLIENT_AUTH_VIEW
 autocomplete DEL_ONION
 autocomplete HSFETCH
 autocomplete HSPOST

--- a/stem/response/__init__.py
+++ b/stem/response/__init__.py
@@ -45,6 +45,7 @@ __all__ = [
   'events',
   'getinfo',
   'getconf',
+  'onion_client_auth',
   'protocolinfo',
   'authchallenge',
   'convert',
@@ -66,14 +67,17 @@ def convert(response_type: str, message: 'stem.response.ControlMessage', **kwarg
   =================== =====
   response_type       Class
   =================== =====
-  **ADD_ONION**       :class:`stem.response.add_onion.AddOnionResponse`
-  **AUTHCHALLENGE**   :class:`stem.response.authchallenge.AuthChallengeResponse`
-  **EVENT**           :class:`stem.response.events.Event` subclass
-  **GETCONF**         :class:`stem.response.getconf.GetConfResponse`
-  **GETINFO**         :class:`stem.response.getinfo.GetInfoResponse`
-  **MAPADDRESS**      :class:`stem.response.mapaddress.MapAddressResponse`
-  **PROTOCOLINFO**    :class:`stem.response.protocolinfo.ProtocolInfoResponse`
-  **SINGLELINE**      :class:`stem.response.SingleLineResponse`
+  **ADD_ONION**                :class:`stem.response.add_onion.AddOnionResponse`
+  **AUTHCHALLENGE**            :class:`stem.response.authchallenge.AuthChallengeResponse`
+  **EVENT**                    :class:`stem.response.events.Event` subclass
+  **GETCONF**                  :class:`stem.response.getconf.GetConfResponse`
+  **GETINFO**                  :class:`stem.response.getinfo.GetInfoResponse`
+  **MAPADDRESS**               :class:`stem.response.mapaddress.MapAddressResponse`
+  **ONION_CLIENT_AUTH_ADD**    :class:`stem.response.onion_client_auth.OnionClientAuthAddResponse`
+  **ONION_CLIENT_AUTH_REMOVE** :class:`stem.response.onion_client_auth.OnionClientAuthRemoveResponse`
+  **ONION_CLIENT_AUTH_VIEW**   :class:`stem.response.onion_client_auth.OnionClientAuthViewResponse`
+  **PROTOCOLINFO**             :class:`stem.response.protocolinfo.ProtocolInfoResponse`
+  **SINGLELINE**               :class:`stem.response.SingleLineResponse`
   =================== =====
 
   :param response_type: type of tor response to convert to
@@ -101,6 +105,7 @@ def convert(response_type: str, message: 'stem.response.ControlMessage', **kwarg
   import stem.response.getinfo
   import stem.response.getconf
   import stem.response.mapaddress
+  import stem.response.onion_client_auth
   import stem.response.protocolinfo
 
   if not isinstance(message, ControlMessage):
@@ -113,6 +118,9 @@ def convert(response_type: str, message: 'stem.response.ControlMessage', **kwarg
     'GETCONF': stem.response.getconf.GetConfResponse,
     'GETINFO': stem.response.getinfo.GetInfoResponse,
     'MAPADDRESS': stem.response.mapaddress.MapAddressResponse,
+    'ONION_CLIENT_AUTH_ADD': stem.response.onion_client_auth.OnionClientAuthAddResponse,
+    'ONION_CLIENT_AUTH_REMOVE': stem.response.onion_client_auth.OnionClientAuthRemoveResponse,
+    'ONION_CLIENT_AUTH_VIEW': stem.response.onion_client_auth.OnionClientAuthViewResponse,
     'PROTOCOLINFO': stem.response.protocolinfo.ProtocolInfoResponse,
     'SINGLELINE': SingleLineResponse,
   }
@@ -153,6 +161,17 @@ def _convert_to_add_onion(message: 'stem.response.ControlMessage', **kwargs: Any
   stem.response.convert('ADD_ONION', message)
   return message  # type: ignore
 
+def _convert_to_onion_client_auth_add(message: 'stem.response.ControlMessage', **kwargs: Any) -> 'stem.response.onion_client_auth.OnionClientAuthAddResponse':
+  stem.response.convert('ONION_CLIENT_AUTH_ADD', message)
+  return message  # type: ignore
+
+def _convert_to_onion_client_auth_remove(message: 'stem.response.ControlMessage', **kwargs: Any) -> 'stem.response.onion_client_auth.OnionClientAuthRemoveResponse':
+  stem.response.convert('ONION_CLIENT_AUTH_REMOVE', message)
+  return message  # type: ignore
+
+def _convert_to_onion_client_auth_view(message: 'stem.response.ControlMessage', **kwargs: Any) -> 'stem.response.onion_client_auth.OnionClientAuthViewResponse':
+  stem.response.convert('ONION_CLIENT_AUTH_VIEW', message)
+  return message  # type: ignore
 
 def _convert_to_mapaddress(message: 'stem.response.ControlMessage', **kwargs: Any) -> 'stem.response.mapaddress.MapAddressResponse':
   stem.response.convert('MAPADDRESS', message)
@@ -226,13 +245,13 @@ class ControlMessage(object):
 
   def is_ok(self) -> bool:
     """
-    Checks if any of our lines have a 250 response.
+    Checks if any of our lines have a 250, 251 or 252 response.
 
-    :returns: **True** if any lines have a 250 response code, **False** otherwise
+    :returns: **True** if any lines have a 250, 251 or 252 response code, **False** otherwise
     """
 
     for code, _, _ in self._parsed_content:
-      if code == '250':
+      if code in ['250', '251', '252']:
         return True
 
     return False

--- a/stem/response/onion_client_auth.py
+++ b/stem/response/onion_client_auth.py
@@ -1,0 +1,58 @@
+# Copyright 2015-2020, Damian Johnson and The Tor Project
+# See LICENSE for licensing information
+
+import stem.response
+from stem.util import log
+
+class OnionClientAuthAddResponse(stem.response.ControlMessage):
+  """
+  ONION_CLIENT_AUTH_ADD response.
+  """
+
+  def _parse_message(self) -> None:
+    # ONION_CLIENT_AUTH_ADD responds with:
+    # '250 OK',
+    # '251 Client for onion existed and replaced',
+    # '252 Registered client and decrypted desc',
+    # '512 Invalid v3 address [service id]',
+    # '553 Unable to store creds for [service id]'
+
+    if not self.is_ok():
+      raise stem.ProtocolError("ONION_CLIENT_AUTH_ADD response didn't have an OK status: %s" % self)
+
+class OnionClientAuthRemoveResponse(stem.response.ControlMessage):
+  """
+  ONION_CLIENT_AUTH_REMOVE response.
+  """
+
+  def _parse_message(self) -> None:
+    # ONION_CLIENT_AUTH_REMOVE responds with:
+    # '250 OK', 
+    # '251 No credentials for [service id]',
+    # '512 Invalid v3 address [service id]'
+
+    if not self.is_ok():
+      raise stem.ProtocolError("ONION_CLIENT_AUTH_REMOVE response didn't have an OK status: %s" % self)
+
+class OnionClientAuthViewResponse(stem.response.ControlMessage):
+  """
+  ONION_CLIENT_AUTH_VIEW response.
+  """
+
+  def _parse_message(self) -> None:
+    # ONION_CLIENT_AUTH_VIEW responds with:
+    # '250 OK' if there was Client Auth for this service or if the service is a valid address,
+    # ''512 Invalid v3 address [service id]'
+
+    self.client_auth_credential = None
+
+    if not self.is_ok():
+      raise stem.ProtocolError("ONION_CLIENT_AUTH_VIEW response didn't have an OK status: %s" % self)
+    else:
+      for line in list(self):
+        if line.startswith('CLIENT'):
+          key, value = line.split(' ', 1)
+          log.debug(key)
+          log.debug(value)
+
+          self.client_auth_credential = value


### PR DESCRIPTION
Hello @atagar,

Per #66, here is an implementation of the client-side Client Auth control port commands for v3 onions.

I added some integration tests which passed for me.

This is my first time contributing to Stem so please do let me know if I did anything incorrectly.

Cheers,
mig5 (from the OnionShare project)