### PR TITLE
Fix open call during hash verification

### DIFF
--- a/stem/descriptor/collector.py
+++ b/stem/descriptor/collector.py
@@ -325,7 +325,7 @@ class File(object):
     # check if this file already exists with the correct checksum
 
     if os.path.exists(path):
-      with open(path, 'b') as prior_file:
+      with open(path, 'rb') as prior_file:
         expected_hash = binascii.hexlify(base64.b64decode(self.sha256)).decode('utf-8')
         actual_hash = hashlib.sha256(prior_file.read()).hexdigest()
 


### PR DESCRIPTION
Minimal example:
``` 
python -c "open('foo', 'b')" 
```
Results in:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ValueError: Must have exactly one of create/read/write/append mode and at most one plus
```