### PR TITLE
Add onion client auth v3 support

### DIFF
--- a/stem/control.py
+++ b/stem/control.py
@@ -2960,7 +2960,6 @@ class Controller(BaseController):
 
       print('service established at %s.onion' % response.service_id)
 
-
     .. versionadded:: 1.4.0
 
     .. versionchanged:: 1.5.0

--- a/stem/version.py
+++ b/stem/version.py
@@ -26,14 +26,15 @@ easily parsed and compared, for instance...
 
   Enumerations for the version requirements of features.
 
-  =========================== ===========
-  Requirement                 Description
-  =========================== ===========
-  **DORMANT_MODE**            **DORMANT** and **ACTIVE** :data:`~stem.Signal`
-  **DROPTIMEOUTS**            **DROPTIMEOUTS** controller command
-  **HSFETCH_V3**              HSFETCH for version 3 hidden services
-  **ONION_CLIENT_AUTH_ADD**   **ONION_CLIENT_AUTH_ADD** controller command
-  =========================== ===========
+  ========================== ===========
+  Requirement                Description
+  ========================== ===========
+  **DORMANT_MODE**           **DORMANT** and **ACTIVE** :data:`~stem.Signal`
+  **DROPTIMEOUTS**           **DROPTIMEOUTS** controller command
+  **HSFETCH_V3**             HSFETCH for version 3 hidden services
+  **ONION_CLIENT_AUTH_ADD**  **ONION_CLIENT_AUTH_ADD** controller command
+  **ONION_SERVICE_AUTH_ADD** For adding ClientAuthV3 to a v3 onion service via ADD_ONION
+  ========================== ===========
 """
 
 import functools
@@ -223,4 +224,5 @@ Requirement = stem.util.enum.Enum(
   ('DROPTIMEOUTS', Version('0.4.5.0-alpha')),
   ('HSFETCH_V3', Version('0.4.1.1-alpha')),
   ('ONION_CLIENT_AUTH_ADD', Version('0.4.3.1-alpha')),
+  ('ONION_SERVICE_AUTH_ADD', Version('0.4.6.1-alpha')),
 )

--- a/test/require.py
+++ b/test/require.py
@@ -125,6 +125,16 @@ def version(req_version):
   return needs(lambda: test.tor_version() >= req_version, 'requires %s' % req_version)
 
 
+def version_older_than(req_version):
+  """
+  Skips the test unless we meet a version older than the requested version.
+
+  :param stem.version.Version req_version: the version that tor should be older than
+  """
+
+  return needs(lambda: test.tor_version() < req_version, 'requires %s' % req_version)
+
+
 cryptography = needs(lambda: CRYPTOGRAPHY_AVAILABLE, 'requires cryptography')
 proc = needs(stem.util.proc.is_available, 'proc unavailable')
 controller = needs(_can_access_controller, 'no connection')


### PR DESCRIPTION
Hi @atagar 

We at OnionShare are excited to be working on support for adding Client Auth  to v3 onions. For that we needed Tor to support it via the control port (which it mostly does now, as of 0.4.6.1-alpha (https://gitlab.torproject.org/legacy/trac/-/issues/30381) - and then of course we need Stem's `create_ephemeral_hidden_service()` to  support sending the arg/flag too.

This PR (hopefully) adds support for adding Client Auth to v3 onions

Since the terminology is a bit confusing and although we use the word 'client' for adding auth even to a service (not just as a Tor *client*), I have named the new version check ONION_SERVICE_AUTH_ADD to differentiate the ONION_CLIENT_AUTH_ADD which is for adding auth client-side.

I see that the code has substantially changed since 1.8.0. I originally patched a copy of 1.8.0 which we are using in OnionShare, but then reworked it to suit what I am guessing is an upcoming 2.0.0...

I hope the tests are ok as well. Since Tor 0.4.6-alpha-1 drops support for v2 onions, I added a new `test.requireversion_older_than()` to skip tests that are for v2 only, so that running `python3 run_tests.py --integ` works successfully on the nightly Tor version (I am using `0.4.7.0-alpha-dev` installed from the nightly Tor Debian repository)

I couldn't seem to run Stem `master` branch inside onionshare, maybe because there are other breaking changes as part of your post-1.8.0 work, I'm not sure. So, I've not literally tested *this* patch, but the tests themselves succeed..

Also please note, in `stem/response/add_onion.py`, I didn't bother setting an attribute for the `ClientAuthV3` because what is returned from the control port is just the public key we've already sent as part of the request. E.G this works differently to BasicAuth on v2 onions, where Tor would send *us* the password that we need to know for using it. Since we already know the public key when adding client auth for v3 onions, I didn't see value in adding `self.client_auth_v3` in the response, but let me know if you think otherwise.

Final note: there is a bug in Tor core right now that means that even though  the control port accepts ClientAuthV3 and the V3Key flag in ADD_ONION, Tor is not actually adding the clientauth to the onion service it creates - meaning that the auth is not *enforced* when trying to visit the Onion Service. I have reported this separately, see:

https://lists.torproject.org/pipermail/tor-dev/2021-May/014548.html
https://gitlab.torproject.org/tpo/core/tor/-/issues/40378
https://gitlab.torproject.org/tpo/core/tor/-/merge_requests/374

Hopefully when that fix gets merged in, we can actually not only test that we can add client auth via ADD_ONION with Stem, but that the onion service itself *requires* the client auth we set.

Still feel like a novice with Stem contributions, so if you think this PR needs reworking, I'm happy to try and fix it..