### PR TITLE
Update to python 3.9

### DIFF
--- a/stem/descriptor/__init__.py
+++ b/stem/descriptor/__init__.py
@@ -1051,7 +1051,7 @@ class Descriptor(object):
     try:
       from cryptography.hazmat.backends import default_backend
       from cryptography.hazmat.primitives.serialization import load_der_public_key
-      from cryptography.utils import int_to_bytes, int_from_bytes
+      from cryptography.utils import int_to_bytes
     except ImportError:
       raise ValueError('Generating the signed digest requires the cryptography module')
 
@@ -1060,7 +1060,7 @@ class Descriptor(object):
     public_exponent = key.public_numbers().e
 
     sig_as_bytes = _bytes_for_block(signature)
-    sig_as_long = int_from_bytes(sig_as_bytes, byteorder='big')  # convert signature to an int
+    sig_as_long = int.from_bytes(sig_as_bytes, byteorder='big')  # convert signature to an int
     blocksize = len(sig_as_bytes)  # 256B for NetworkStatusDocuments, 128B for others
 
     # use the public exponent[e] & the modulus[n] to decrypt the int


### PR DESCRIPTION
Closes #105 

Since python 3.2: https://docs.python.org/3/library/stdtypes.html#int.from_bytes

Will need a new release - an increased patch-level should be enough.