### PR TITLE
Fixup for Python 3.10

### DIFF
--- a/stem/control.py
+++ b/stem/control.py
@@ -247,6 +247,7 @@ If you're fine with allowing your script to raise exceptions then this can be mo
 import asyncio
 import calendar
 import collections
+import collections.abc
 import datetime
 import functools
 import inspect
@@ -2496,7 +2497,7 @@ class Controller(BaseController):
     for param, value in params_list:
       if isinstance(value, str):
         query_comp.append('%s="%s"' % (param, value.strip()))
-      elif isinstance(value, collections.Iterable):
+      elif isinstance(value, collections.abc.Iterable):
         query_comp.extend(['%s="%s"' % (param, val.strip()) for val in value])
       elif not value:
         query_comp.append(param)


### PR DESCRIPTION
Closes issue #109.  Long story short: a few names from collection are
now moved to collection.abc exclusively starting in Python 3.10. The
only name this app uses from there that was moved is
collections.Iterable.  Code has been added to work around this API quirk
in Python 3.10.