### PR TITLE
Use daemon attribute instead of deprecated setDaemon

### DIFF
--- a/docs/_static/example/fibonacci_threaded.py
+++ b/docs/_static/example/fibonacci_threaded.py
@@ -16,7 +16,7 @@ def main():
 
   for i in range(4):
     t = threading.Thread(target = fibonacci, args = (35,))
-    t.setDaemon(True)
+    t.daemon = True
     t.start()
 
     threads.append(t)

--- a/stem/connection.py
+++ b/stem/connection.py
@@ -278,7 +278,7 @@ def connect(control_port: Tuple[str, Union[str, int]] = ('127.0.0.1', 'default')
 
   loop = asyncio.new_event_loop()
   loop_thread = threading.Thread(target = loop.run_forever, name = 'asyncio')
-  loop_thread.setDaemon(True)
+  loop_thread.daemon = True
   loop_thread.start()
 
   try:

--- a/stem/control.py
+++ b/stem/control.py
@@ -964,7 +964,7 @@ class BaseController(Synchronous):
             args = (self, state, change_timestamp)
 
             notice_thread = threading.Thread(target = listener, args = args, name = '%s notification' % state)
-            notice_thread.setDaemon(True)
+            notice_thread.daemon = True
             notice_thread.start()
             self._state_change_threads.append(notice_thread)
           else:

--- a/stem/util/test_tools.py
+++ b/stem/util/test_tools.py
@@ -173,7 +173,7 @@ class AsyncTest(object):
             name = 'Background test of %s' % self.name,
           )
 
-          self._process.setDaemon(True)
+          self._process.daemon = True
         else:
           self._process = multiprocessing.Process(target = _wrapper, args = (child_pipe, self._runner, self._runner_args))
 


### PR DESCRIPTION
Stem uses `setDaemon`, which causes warnings like the following:
```
/usr/lib/python3.10/site-packages/stem-1.8.0-py3.10.egg/stem/control.py:934: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
  self._event_thread.setDaemon(True)
```

Therefore, I have replaced it with the `daemon` attribute, which is available since Python 2.6 (https://docs.python.org/2.7/library/threading.html#threading.Thread.daemon) and has been deprecated since Python 3.10 (https://docs.python.org/3.10/library/threading.html#threading.Thread.setDaemon).