### PR TITLE
don't use deprecated int_from_byte to test cryptography

### DIFF
--- a/test/require.py
+++ b/test/require.py
@@ -29,7 +29,7 @@ import test
 import test.runner
 
 try:
-  from cryptography.utils import int_from_bytes, int_to_bytes
+  from cryptography.utils import int_to_bytes
   from cryptography.hazmat.backends import default_backend
   from cryptography.hazmat.backends.openssl.backend import backend
   from cryptography.hazmat.primitives.asymmetric import rsa

--- a/test/settings.cfg
+++ b/test/settings.cfg
@@ -207,7 +207,6 @@ pyflakes.ignore stem/socket.py => redefinition of unused '_recv'*
 pyflakes.ignore stem/util/__init__.py => undefined name 'cryptography'
 pyflakes.ignore stem/util/conf.py => undefined name 'stem'
 pyflakes.ignore stem/util/enum.py => undefined name 'stem'
-pyflakes.ignore test/require.py => 'cryptography.utils.int_from_bytes' imported but unused
 pyflakes.ignore test/require.py => 'cryptography.utils.int_to_bytes' imported but unused
 pyflakes.ignore test/require.py => 'cryptography.hazmat.backends.default_backend' imported but unused
 pyflakes.ignore test/require.py => 'cryptography.hazmat.primitives.ciphers.algorithms' imported but unused


### PR DESCRIPTION
https://github.com/pyca/cryptography/pull/6652/files
function int_from_bytes in cryptography.util will be removed form cryptography 37.0, which will be released in April 26ish, which will break stem's cryptography detection because it try to import them
 only place we call this function is to test if cryptography exsit, so we can safely remove them