### PR TITLE
Maint0.8.x 01

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,121 @@
+# core/tor releases:
+# https://gitlab.torproject.org/tpo/core/team/-/wikis/NetworkTeam/CoreTorReleases
+# 0.4.9
+# 0.4.8
+# 0.4.7 stable by March 15, 2022
+# ~~0.4.6 EOL on or after June 15, 2022~~
+# 0.4.5 (LTS) EOL Feb 15, 2023
+# Python stable releases: https://www.python.org/downloads/
+# 3.10 EOL 2026-10, PEP 619
+# 3.9 EOL 2025-10, PEP 596
+# 3.8 EOL 2024-10, PEP 569
+# 3.7 EOL 2023-06-27, PEP 537
+
+variables:
+  BASE_IMAGE: python:3.9
+  RELEASE: tor-nightly-main-bullseye
+  # Without version, the default available in the Debian repository will be
+  # installed.
+  # Specifying which version starts with will install the highest that start
+  # with that version.
+  TOR: tor/tor-nightly-main-bullseye
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
+
+cache:
+  paths:
+    - .cache/pip
+
+image: $BASE_IMAGE
+
+before_script:
+  - "wget https://deb.torproject.org/torproject.org/\
+    A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc"
+  - cat A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc  | apt-key add -
+  - echo deb [signed-by=A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89]
+    http://deb.torproject.org/torproject.org $RELEASE
+    main >> /etc/apt/sources.list
+  - apt update -yqq
+  - apt install -yqq $TOR
+  - pip install tox
+  - python --version
+  - tor --version
+
+python37:
+  variables:
+    BASE_IMAGE: python:3.7
+  script:
+    - tox -e py37
+
+python38:
+  variables:
+    BASE_IMAGE: python:3.8
+  script:
+    - tox -e py38
+
+python39tor045:
+  variables:
+    RELEASE: tor-nightly-0.4.5.x-bullseye
+    TOR: tor/tor-nightly-0.4.5.x-bullseye
+  script:
+    - tox -e py39
+
+python39tormaster:
+  # This will overwrite the default before_script, so need to repeat the
+  # commands
+  before_script:
+    - "wget https://deb.torproject.org/torproject.org/\
+      A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc"
+    - cat A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc  | apt-key add -
+    - echo deb [signed-by=A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89]
+      http://deb.torproject.org/torproject.org $RELEASE
+      main >> /etc/apt/sources.list
+    - apt update -yqq
+    - apt install -yqq $TOR
+    - pip install tox
+    - python --version
+    - tor --version
+    # To build the docs
+    - apt install -yqq texlive-latex-extra
+    - apt install -yqq dvipng
+  script:
+    - tox -e py39
+
+python39torstable:
+  variables:
+    BASE_IMAGE: python:3.9
+    RELEASE: bullseye
+    TOR: tor/bullseye
+  script:
+    - tox -e py39
+
+python310:
+  variables:
+    BASE_IMAGE: python:3.10
+  script:
+    - tox -e py310
+
+release_job:
+  before_script:
+    - echo "Nothing"
+  after_script:
+    - echo "Nothing"
+  image: registry.gitlab.com/gitlab-org/release-cli:latest
+  only: [tags]
+  script:
+    - echo "Running release job."
+  release:
+    name: "Release $CI_COMMIT_TAG"
+    description: "Created using release-cli"
+    tag_name: "$CI_COMMIT_TAG"
+    ref: "$CI_COMMIT_TAG"
+    milestones:
+      - "stem: 1.8.1"
+
+pages:
+  before_script:
+    - pip install sphinx
+  script:
+    - cd docs && make html && mv _build/html ../public
+  artifacts:
+    paths:
+      - public

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 ## Stem (Python Tor Library)
 
+**NOTE**: Stem is mostly unmaintained. However, you can still:
+
+* Open issues at <https://github.com/torproject/stem/issues>
+* Work on an issue and open a pull request at <https://github.com/torproject/stem/pulls>
+* Contact us (via tor-dev mailing list or gk at torproject dot org) to request
+    a new bugfix release including some patches in the Stem's `master` branch or
+    pull requests.
 
 Stem is a Python controller library for **[Tor](https://www.torproject.org/)**. With it you can use Tor's [control protocol](https://gitweb.torproject.org/torspec.git/tree/control-spec.txt) to script against the Tor process, or build things such as [Nyx](https://nyx.torproject.org/).
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,15 @@
 Welcome to Stem!
 ================
 
-Stem is a Python controller library for `Tor <https://www.torproject.org/>`_. With it you can use Tor's `control protocol <https://gitweb.torproject.org/torspec.git/tree/control-spec.txt>`_ to script against the Tor process, or build things such as `Nyx <https://nyx.torproject.org/>`_. Stem's latest version is **1.8** (released December 29th, 2019).
+.. NOTE:: Stem is mostly unmaintained. However, you can still:
+
+   * Open issues at https://github.com/torproject/stem/issues
+   * Work on an issue and open a pull request at https://github.com/torproject/stem/pulls
+   * Contact us (via tor-dev mailing list or gk at torproject dot org) to request
+     a new bugfix release including some patches in the Stem's `master` branch or
+     pull requests.
+
+Stem is a Python controller library for `Tor <https://www.torproject.org/>`_. With it you can use Tor's `control protocol <https://gitweb.torproject.org/torspec.git/tree/control-spec.txt>`_ to script against the Tor process, or build things such as `Nyx <https://nyx.torproject.org/>`_. Stem's latest version is **1.8.1** (released September, 2022).
 
 .. Main Stem Logo
    Source: http://www.wpclipart.com/plants/assorted/P/plant_stem.png.html

--- a/stem/__init__.py
+++ b/stem/__init__.py
@@ -507,7 +507,7 @@ import traceback
 import stem.util
 import stem.util.enum
 
-__version__ = '1.8.0-maint'
+__version__ = '1.8.1'
 __author__ = 'Damian Johnson'
 __contact__ = 'atagar@torproject.org'
 __url__ = 'https://stem.torproject.org/'

--- a/stem/__init__.py
+++ b/stem/__init__.py
@@ -507,7 +507,7 @@ import traceback
 import stem.util
 import stem.util.enum
 
-__version__ = '1.8.1'
+__version__ = '1.8.1-maint'
 __author__ = 'Damian Johnson'
 __contact__ = 'atagar@torproject.org'
 __url__ = 'https://stem.torproject.org/'

--- a/stem/control.py
+++ b/stem/control.py
@@ -248,7 +248,7 @@ If you're fine with allowing your script to raise exceptions then this can be mo
 """
 
 import calendar
-import collections
+import collections.abc
 import functools
 import inspect
 import io
@@ -2532,7 +2532,7 @@ class Controller(BaseController):
     for param, value in params:
       if isinstance(value, str):
         query_comp.append('%s="%s"' % (param, value.strip()))
-      elif isinstance(value, collections.Iterable):
+      elif isinstance(value, collections.abc.Iterable):
         query_comp.extend(['%s="%s"' % (param, val.strip()) for val in value])
       elif not value:
         query_comp.append(param)

--- a/stem/control.py
+++ b/stem/control.py
@@ -3025,7 +3025,7 @@ class Controller(BaseController):
     .. versionchanged:: 1.7.0
        Added the timeout and max_streams arguments.
 
-    .. versionchanged:: 1.9.0
+    .. versionchanged:: 1.8.1
        Added the client_auth_v3 argument.
 
     :param int,list,dict ports: hidden service port(s) or mapping of hidden


### PR DESCRIPTION
Release 1.8.1 and bump maintenance version.

@atagar: this pull request is to release a 1.8.1 version, in which @gk-tpo have been working on at https://gitlab.torproject.org/tpo/network-health/team/-/issues/262.

If it's fine for you, you can either merge it or let us know that is fine to merge. I can then also push the tag (see https://github.com/juga0/stem/releases/tag/1.8.1) and create the release here.

Thanks!