### PR TITLE
Python 3.11 compatibility fix for deprecated coroutine decorator

### DIFF
--- a/stem/util/asyncio.py
+++ b/stem/util/asyncio.py
@@ -92,7 +92,10 @@ class Synchronous(object):
           setattr(self, name, functools.partial(self._run_async_method, name))
 
       Synchronous.start(self)
-      asyncio.run_coroutine_threadsafe(asyncio.coroutine(self.__ainit__)(), self._loop).result()
+
+      async def convert_ainit():
+        return self.__ainit__()
+      asyncio.run_coroutine_threadsafe(convert_ainit(), self._loop).result()
 
   def __ainit__(self):
     """


### PR DESCRIPTION
The code to run __ainit__ constructors in the Synchronous mixin was using the deprecated asyncio.coroutine() decorator, which was fully removed in Python 3.11. Thankfully we can use the same approach for ainit that this same class uses below for wrapping generators.