### PR TITLE
Update create_ephemeral_hidden_service() to allow multiple v3 client auth keys

### DIFF
--- a/stem/control.py
+++ b/stem/control.py
@@ -2891,7 +2891,7 @@ class Controller(BaseController):
 
     return [r for r in result if r]  # drop any empty responses (GETINFO is blank if unset)
 
-  async def create_ephemeral_hidden_service(self, ports: Union[int, Sequence[int], Mapping[int, str]], key_type: str = 'NEW', key_content: str = 'BEST', discard_key: bool = False, detached: bool = False, await_publication: bool = False, timeout: Optional[float] = None, basic_auth: Optional[Mapping[str, str]] = None, max_streams: Optional[int] = None, client_auth_v3: Optional[str] = None) -> stem.response.add_onion.AddOnionResponse:
+  async def create_ephemeral_hidden_service(self, ports: Union[int, Sequence[int], Mapping[int, str]], key_type: str = 'NEW', key_content: str = 'BEST', discard_key: bool = False, detached: bool = False, await_publication: bool = False, timeout: Optional[float] = None, basic_auth: Optional[Mapping[str, str]] = None, max_streams: Optional[int] = None, client_auth_v3: Optional[Union[str, Sequence[str]]] = None) -> stem.response.add_onion.AddOnionResponse:
     """
     Creates a new hidden service. Unlike
     :func:`~stem.control.Controller.create_hidden_service` this style of
@@ -2994,7 +2994,7 @@ class Controller(BaseController):
     :param basic_auth: required user credentials to access a v2 service
     :param max_streams: maximum number of streams the hidden service will
       accept, unlimited if zero or not set
-    :param str client_auth_v3: base32-encoded public key for **version 3**
+    :param str client_auth_v3: base32-encoded public key(s) for **version 3**
       onion services that require client authentication
 
     :returns: :class:`~stem.response.add_onion.AddOnionResponse` with the response
@@ -3063,8 +3063,13 @@ class Controller(BaseController):
         else:
           request += ' ClientAuth=%s' % client_name
 
-    if client_auth_v3 is not None:
+    if isinstance(client_auth_v3, str):
       request += ' ClientAuthV3=%s' % client_auth_v3
+    elif isinstance(client_auth_v3, list):
+      for v3key in client_auth_v3:
+        request += ' ClientAuthV3=%s' % v3key
+    else:
+      raise ValueError("The 'client_auth_v3' argument of create_ephemeral_hidden_service() needs to be a str or list")
 
     response = stem.response._convert_to_add_onion(stem.response._convert_to_add_onion(await self.msg(request)))
 

--- a/test/integ/control/controller.py
+++ b/test/integ/control/controller.py
@@ -741,6 +741,29 @@ class TestController(unittest.TestCase):
   @test.require.controller
   @test.require.version(stem.version.Requirement.ONION_SERVICE_AUTH_ADD)
   @async_test
+  async def test_with_ephemeral_hidden_services_v3_client_auth_multiple_keys(self):
+    """
+    Exercises creating v3 ephemeral hidden services with ClientAuthV3.
+    """
+
+    runner = test.runner.get_runner()
+
+    async with await runner.get_tor_controller() as controller:
+      client_auth_v3_keys = ['FGTORMIDKR7T2PR632HSHLWA4G6HF5TCWSGMHDUU4LWBEFTAVYQQ', 'IIFY5QJBTQDEU5IUBZRQVZV3DBWRKZLDYXSRUP7WYYDKSBPCQVVQ']
+      response = await controller.create_ephemeral_hidden_service(4567, key_content = 'ED25519-V3', client_auth_v3=client_auth_v3_keys)
+      self.assertEqual([response.service_id], await controller.list_ephemeral_hidden_services())
+      self.assertTrue(response.private_key is not None)
+      self.assertEqual('ED25519-V3', response.private_key_type)
+      self.assertEqual({}, response.client_auth)
+
+      # drop the service
+
+      self.assertEqual(True, await controller.remove_ephemeral_hidden_service(response.service_id))
+      self.assertEqual([], await controller.list_ephemeral_hidden_services())
+
+  @test.require.controller
+  @test.require.version(stem.version.Requirement.ONION_SERVICE_AUTH_ADD)
+  @async_test
   async def test_with_ephemeral_hidden_services_v3_client_auth_invalid(self):
     """
     Exercises creating v3 ephemeral hidden services with ClientAuthV3 but


### PR DESCRIPTION
The TOR control protocol allows for multiple `ClientAuthV3` arguments with the `ADD_ONION` command ([link to specification](https://gitlab.torproject.org/tpo/core/torspec/-/blob/main/control-spec.txt#L1758)).
This pull request updates the `create_ephemeral_hidden_service()` function to enable this functionality.

I tested this with TOR version `0.4.7.10 (git-f732a91a73be3ca6)`.