### PR TITLE
add new line at the end of inner hs descriptor

### DIFF
--- a/stem/descriptor/hidden_service.py
+++ b/stem/descriptor/hidden_service.py
@@ -1302,9 +1302,9 @@ class InnerLayer(Descriptor):
   @classmethod
   def content(cls: Type['stem.descriptor.hidden_service.InnerLayer'], attr: Optional[Mapping[str, str]] = None, exclude: Sequence[str] = (), introduction_points: Optional[Sequence['stem.descriptor.hidden_service.IntroductionPointV3']] = None) -> bytes:
     if introduction_points:
-      suffix = '\n' + '\n'.join(map(IntroductionPointV3.encode, introduction_points))
+      suffix = '\n' + '\n'.join(map(IntroductionPointV3.encode, introduction_points)) + '\n'
     else:
-      suffix = ''
+      suffix = '\n'
 
     return _descriptor_content(attr, exclude, (
       ('create2-formats', '2'),


### PR DESCRIPTION
this seems to be the root cause of [tpo/core/arti#952](https://gitlab.torproject.org/tpo/core/arti/-/issues/952). Not having this new line seems [out of spec](https://gitlab.torproject.org/tpo/core/torspec/-/blob/1f5d4691f0d4bdd4082ad2405216ed4c89a04caa/rend-spec-v3.txt#L1368), each entry is supposed to end with a NL, including the final one.

I'm not entirely sure if the change is required in the case there is no intro points. I think it is but I'm not familiar enough with the code to make sure myself.