### PR TITLE
Update extrainfo_descriptor.py

### DIFF
--- a/stem/descriptor/extrainfo_descriptor.py
+++ b/stem/descriptor/extrainfo_descriptor.py
@@ -671,7 +671,7 @@ class ExtraInfoDescriptor(Descriptor):
   :var datetime geoip_start_time: replaced by bridge_stats_end (deprecated)
   :var dict geoip_client_origins: replaced by bridge_ips (deprecated)
   :var dict ip_versions: mapping of ip protocols to a rounded count for the number of users
-  :var dict ip_versions: mapping of ip transports to a count for the number of users
+  :var dict ip_transports: mapping of ip transports to a count for the number of users
 
   **\\*** attribute is either required when we're parsed with validation or has
   a default value, others are left as **None** if undefined


### PR DESCRIPTION
Fixing this -
"ip_versions" is repeated twice
![image](https://github.com/aadarsh-nagrath/stem/assets/92307537/3a3fdc4f-4dd5-4690-9b2a-ba633cd599b3)
Documentation for ExtraInfoDescriptor.ip_transports calls it ip_versions  
#120