### PR TITLE
Fix breakage with cryptography>=42

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1707578295,
+        "narHash": "sha256-7QXnfi0g+lLRTsQOQUcVJiEgU9oN4muqyWSqk6+IhKY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ecbb6c4c9100d581da3c1163438fbde1ce763f66",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "Controller library that allows applications to interact with Tor";
+
+  outputs = { self, nixpkgs }:
+    let
+      inherit (nixpkgs) lib;
+      forAllSystems = lib.genAttrs lib.systems.flakeExposed;
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          packages = self.packages.${system};
+        in
+        {
+          super = pkgs.python3Packages.stem;
+          stem = packages.super.overrideAttrs {
+            src = ./.;
+          };
+          default = packages.stem;
+        });
+    };
+}

--- a/stem/client/__init__.py
+++ b/stem/client/__init__.py
@@ -315,7 +315,6 @@ class Circuit(object):
   def __init__(self, relay: 'stem.client.Relay', circ_id: int, kdf: 'stem.client.datatype.KDF') -> None:
     try:
       from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-      from cryptography.hazmat.backends import default_backend
     except ImportError:
       raise ImportError('Circuit construction requires the cryptography module')
 
@@ -325,8 +324,8 @@ class Circuit(object):
     self.id = circ_id
     self.forward_digest = hashlib.sha1(kdf.forward_digest)
     self.backward_digest = hashlib.sha1(kdf.backward_digest)
-    self.forward_key = Cipher(algorithms.AES(kdf.forward_key), ctr, default_backend()).encryptor()
-    self.backward_key = Cipher(algorithms.AES(kdf.backward_key), ctr, default_backend()).decryptor()
+    self.forward_key = Cipher(algorithms.AES(kdf.forward_key), ctr).encryptor()
+    self.backward_key = Cipher(algorithms.AES(kdf.backward_key), ctr).decryptor()
 
   async def directory(self, request: str, stream_id: int = 0) -> bytes:
     """

--- a/stem/descriptor/hidden_service.py
+++ b/stem/descriptor/hidden_service.py
@@ -731,7 +731,15 @@ class HiddenServiceDescriptorV2(HiddenServiceDescriptor):
           digest_content = self._content_range('rendezvous-service-descriptor ', '\nsignature\n')
           content_digest = hashlib.sha1(digest_content).hexdigest().upper()
 
-          if signed_digest != content_digest:
+          # When signing, the cryptography module includes a constant prefix
+          # indicating the hash algorithm used. Tor doesn't. This causes
+          # signature validation failures and unfortunately cryptography have
+          # no nice way of excluding these. To work around this, we only
+          # validate that the digest ends with the correct suffix.
+          #
+          #   https://github.com/pyca/cryptography/issues/3713
+          #
+          if not signed_digest.endswith(content_digest):
             raise ValueError('Decrypted digest does not match local digest (calculated: %s, local: %s)' % (signed_digest, content_digest))
         except ImportError:
           pass  # cryptography module unavailable

--- a/stem/descriptor/server_descriptor.py
+++ b/stem/descriptor/server_descriptor.py
@@ -772,7 +772,16 @@ class RelayDescriptor(ServerDescriptor):
         try:
           signed_digest = self._digest_for_signature(self.signing_key, self.signature)
 
-          if signed_digest != self.digest():
+
+          # When signing, the cryptography module includes a constant prefix
+          # indicating the hash algorithm used. Tor doesn't. This causes
+          # signature validation failures and unfortunately cryptography have
+          # no nice way of excluding these. To work around this, we only
+          # validate that the digest ends with the correct suffix.
+          #
+          #   https://github.com/pyca/cryptography/issues/3713
+          #
+          if not signed_digest.endswith(self.digest()):
             raise ValueError('Decrypted digest does not match local digest (calculated: %s, local: %s)' % (signed_digest, self.digest()))
 
           if self.onion_key_crosscert:

--- a/test/require.py
+++ b/test/require.py
@@ -30,7 +30,6 @@ import test.runner
 
 try:
   from cryptography.utils import int_to_bytes
-  from cryptography.hazmat.backends import default_backend
   from cryptography.hazmat.backends.openssl.backend import backend
   from cryptography.hazmat.primitives.asymmetric import rsa
   from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes

--- a/test/settings.cfg
+++ b/test/settings.cfg
@@ -208,7 +208,6 @@ pyflakes.ignore stem/util/__init__.py => undefined name 'cryptography'
 pyflakes.ignore stem/util/conf.py => undefined name 'stem'
 pyflakes.ignore stem/util/enum.py => undefined name 'stem'
 pyflakes.ignore test/require.py => 'cryptography.utils.int_to_bytes' imported but unused
-pyflakes.ignore test/require.py => 'cryptography.hazmat.backends.default_backend' imported but unused
 pyflakes.ignore test/require.py => 'cryptography.hazmat.primitives.ciphers.algorithms' imported but unused
 pyflakes.ignore test/require.py => 'cryptography.hazmat.primitives.ciphers.Cipher' imported but unused
 pyflakes.ignore test/require.py => 'cryptography.hazmat.primitives.ciphers.modes' imported but unused

--- a/test/unit/descriptor/hidden_service_v3.py
+++ b/test/unit/descriptor/hidden_service_v3.py
@@ -253,7 +253,7 @@ class TestHiddenServiceDescriptorV3(unittest.TestCase):
       pubkey_b64 = base64.b64encode(pubkey)
       return stem.util.str_tools._to_unicode(pubkey_b64)
 
-    from cryptography.hazmat.backends.openssl.x25519 import X25519PublicKey
+    from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PublicKey
 
     intro_point = InnerLayer(INNER_LAYER_STR).introduction_points[0]
 


### PR DESCRIPTION
This fixes the package for cryptography>=42 (which was [broken](https://hydra.nixos.org/build/249078619/nixlog/2)). The important changes are concentrated on the last commit:

- the magical [`_backend` workaround](https://github.com/torproject/stem/commit/a41767c7363b2164cad7d666a927ff8eead75799) stops working as upstream switches to the new rust backend. To fix this, we now only validate the suffix of the digest.
- import `X25519PublicKey` from the updated path.

Some other changes are also added along the way, in other commits:
- clean up cryptography *_backends as they have been deprecated upstream. These are all dead code as they will be silently ignored by the cryptography module.
- add `flake.{nix,lock}` for easy dev env and reproducible build with the Nix package manager. If this is undesirable I can remove this commit!