### PR TITLE
fix: replace assertRaisesRegexp with assertRaisesRegex

### DIFF
--- a/stem/util/test_tools.py
+++ b/stem/util/test_tools.py
@@ -238,7 +238,7 @@ class TimedTestRunner(unittest.TextTestRunner):
         def assertRaisesWith(self, exc_type: Type[Exception], exc_msg: str, *args: Any, **kwargs: Any) -> None:
           """
           Asserts the given invokation raises the expected excepiton. This is
-          similar to unittest's assertRaises and assertRaisesRegexp, but checks
+          similar to unittest's assertRaises and assertRaisesRegex, but checks
           for an exact match.
 
           This method is **not** being vended to external users and may be
@@ -246,7 +246,7 @@ class TimedTestRunner(unittest.TextTestRunner):
           vended API then please let us know.
           """
 
-          return self.assertRaisesRegexp(exc_type, '^%s$' % re.escape(exc_msg), *args, **kwargs)
+          return self.assertRaisesRegex(exc_type, '^%s$' % re.escape(exc_msg), *args, **kwargs)
 
         def shortDescription(self):
           # Python now prints the first line of a test's docstring by default.

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -20,6 +20,8 @@ import os
 import stem.util.enum
 import stem.version
 
+from unittest import TestCase
+
 __all__ = [
   'network',
   'output',
@@ -78,6 +80,9 @@ if os.path.exists(GIT_IGNORE_PATH):
 if os.path.exists(os.path.join(STEM_BASE, '.travis.yml')):
     IGNORED_FILE_TYPES.append('.travis.yml')
 
+# Allow test cases to run on both Python2 and Python3
+if not hasattr(TestCase, 'assertRaisesRegex'):
+    TestCase.assertRaisesRegex = TestCase.assertRaisesRegexp
 
 def get_new_capabilities():
   """

--- a/test/integ/control/controller.py
+++ b/test/integ/control/controller.py
@@ -1745,13 +1745,13 @@ class TestController(unittest.TestCase):
       invalid_service_id = 'xxxxxxxxyvhz3ofkv7gwf5hpzqvhonpr3gbax2cc7dee3xcnt7dmtlx2gu7vyvid'
       exc_msg = "^%%s response didn't have an OK status: Invalid v3 (addr|address) \"%s\"$" % invalid_service_id
 
-      with self.assertRaisesRegexp(stem.ProtocolError, exc_msg % 'ONION_CLIENT_AUTH_ADD'):
+      with self.assertRaisesRegex(stem.ProtocolError, exc_msg % 'ONION_CLIENT_AUTH_ADD'):
         await controller.add_hidden_service_auth(invalid_service_id, PRIVATE_KEY)
 
-      with self.assertRaisesRegexp(stem.ProtocolError, exc_msg % 'ONION_CLIENT_AUTH_REMOVE'):
+      with self.assertRaisesRegex(stem.ProtocolError, exc_msg % 'ONION_CLIENT_AUTH_REMOVE'):
         await controller.remove_hidden_service_auth(invalid_service_id)
 
-      with self.assertRaisesRegexp(stem.ProtocolError, exc_msg % 'ONION_CLIENT_AUTH_VIEW'):
+      with self.assertRaisesRegex(stem.ProtocolError, exc_msg % 'ONION_CLIENT_AUTH_VIEW'):
         await controller.list_hidden_service_auth(invalid_service_id)
 
       invalid_key = 'XXXXXXXXXFCV0c0ELDKKDpSFgVIB8Yow8Evj5iD+GoiTtK878NkQ='

--- a/test/integ/descriptor/collector.py
+++ b/test/integ/descriptor/collector.py
@@ -88,7 +88,7 @@ class TestCollector(unittest.TestCase):
     )
 
     for args, expected_msg in test_values:
-      self.assertRaisesRegexp(ValueError, re.escape(expected_msg), list, stem.descriptor.collector.get_consensus(**args))
+      self.assertRaisesRegex(ValueError, re.escape(expected_msg), list, stem.descriptor.collector.get_consensus(**args))
 
   def _test_index(self, compression):
     if compression and not compression.available:

--- a/test/unit/client/cell.py
+++ b/test/unit/client/cell.py
@@ -213,7 +213,7 @@ class TestCell(unittest.TestCase):
     self.assertEqual(3257622417, RelayCell(5, 'RELAY_BEGIN_DIR', '', digest.digest(), 564346860).digest)
     self.assertEqual(3257622417, RelayCell(5, 'RELAY_BEGIN_DIR', '', 3257622417, 564346860).digest)
     self.assertRaisesWith(ValueError, 'RELAY cell digest must be a hash, string, or int but was a list', RelayCell, 5, 'RELAY_BEGIN_DIR', '', [], 564346860)
-    self.assertRaisesRegexp(ValueError, "Invalid enumeration 'NO_SUCH_COMMAND', options are RELAY_BEGIN, RELAY_DATA", RelayCell, 5, 'NO_SUCH_COMMAND', '', 5, 564346860)
+    self.assertRaisesRegex(ValueError, "Invalid enumeration 'NO_SUCH_COMMAND', options are RELAY_BEGIN, RELAY_DATA", RelayCell, 5, 'NO_SUCH_COMMAND', '', 5, 564346860)
 
     mismatched_data_length_bytes = b''.join((
       b'\x00\x01',  # circ ID

--- a/test/unit/descriptor/certificate.py
+++ b/test/unit/descriptor/certificate.py
@@ -117,7 +117,7 @@ class TestEd25519Certificate(unittest.TestCase):
     """
 
     exc_msg = re.escape("Ed25519 certificate wasn't propoerly base64 encoded (Incorrect padding):")
-    self.assertRaisesRegexp(ValueError, exc_msg, Ed25519Certificate.from_base64, '\x02\x0323\x04')
+    self.assertRaisesRegex(ValueError, exc_msg, Ed25519Certificate.from_base64, '\x02\x0323\x04')
 
   def test_too_short(self):
     """

--- a/test/unit/descriptor/collector.py
+++ b/test/unit/descriptor/collector.py
@@ -102,19 +102,19 @@ class TestCollector(unittest.TestCase):
     urlopen_mock.side_effect = OSError('boom')
 
     collector = CollecTor(retries = 0)
-    self.assertRaisesRegexp(OSError, 'boom', collector.index)
+    self.assertRaisesRegex(OSError, 'boom', collector.index)
     self.assertEqual(1, urlopen_mock.call_count)
 
     urlopen_mock.reset_mock()
 
     collector = CollecTor(retries = 4)
-    self.assertRaisesRegexp(OSError, 'boom', collector.index)
+    self.assertRaisesRegex(OSError, 'boom', collector.index)
     self.assertEqual(5, urlopen_mock.call_count)
 
   @patch('urllib.request.urlopen', Mock(return_value = io.BytesIO(b'not json')))
   def test_index_malformed_json(self):
     collector = CollecTor()
-    self.assertRaisesRegexp(ValueError, 'Expecting value: line 1 column 1', collector.index, Compression.PLAINTEXT)
+    self.assertRaisesRegex(ValueError, 'Expecting value: line 1 column 1', collector.index, Compression.PLAINTEXT)
 
   def test_index_malformed_compression(self):
     for compression in (Compression.GZIP, Compression.BZ2, Compression.LZMA):
@@ -123,7 +123,7 @@ class TestCollector(unittest.TestCase):
 
       with patch('urllib.request.urlopen', Mock(return_value = io.BytesIO(b'not compressed'))):
         collector = CollecTor()
-        self.assertRaisesRegexp(OSError, 'Failed to decompress as %s' % compression, collector.index, compression)
+        self.assertRaisesRegex(OSError, 'Failed to decompress as %s' % compression, collector.index, compression)
 
   @patch('stem.descriptor.collector.CollecTor.index', Mock(return_value = EXAMPLE_INDEX))
   def test_files(self):

--- a/test/unit/descriptor/remote.py
+++ b/test/unit/descriptor/remote.py
@@ -181,7 +181,7 @@ class TestDescriptorDownloader(unittest.TestCase):
         skip_crypto_validation = not test.require.CRYPTOGRAPHY_AVAILABLE,
       )
 
-      self.assertRaisesRegexp(stem.ProtocolError, "^Response should begin with HTTP success, but was 'HTTP/1.0 500 Kaboom'", request.run)
+      self.assertRaisesRegex(stem.ProtocolError, "^Response should begin with HTTP success, but was 'HTTP/1.0 500 Kaboom'", request.run)
 
   @mock_download(TEST_DESCRIPTOR)
   def test_reply_header_data(self):

--- a/test/unit/directory/authority.py
+++ b/test/unit/directory/authority.py
@@ -72,4 +72,4 @@ class TestAuthority(unittest.TestCase):
 
   @patch('urllib.request.urlopen', Mock(return_value = io.BytesIO(b'')))
   def test_from_remote_empty(self):
-    self.assertRaisesRegexp(stem.DownloadFailed, 'no content', stem.directory.Authority.from_remote)
+    self.assertRaisesRegex(stem.DownloadFailed, 'no content', stem.directory.Authority.from_remote)

--- a/test/unit/directory/fallback.py
+++ b/test/unit/directory/fallback.py
@@ -100,15 +100,15 @@ class TestFallback(unittest.TestCase):
 
   @patch('urllib.request.urlopen', Mock(return_value = io.BytesIO(b'')))
   def test_from_remote_empty(self):
-    self.assertRaisesRegexp(stem.DownloadFailed, 'no content', stem.directory.Fallback.from_remote)
+    self.assertRaisesRegex(stem.DownloadFailed, 'no content', stem.directory.Fallback.from_remote)
 
   @patch('urllib.request.urlopen', Mock(return_value = io.BytesIO(b'\n'.join(FALLBACK_GITLAB_CONTENT.splitlines()[1:]))))
   def test_from_remote_no_header(self):
-    self.assertRaisesRegexp(OSError, 'does not have a type field indicating it is fallback directory metadata', stem.directory.Fallback.from_remote)
+    self.assertRaisesRegex(OSError, 'does not have a type field indicating it is fallback directory metadata', stem.directory.Fallback.from_remote)
 
   @patch('urllib.request.urlopen', Mock(return_value = io.BytesIO(FALLBACK_GITLAB_CONTENT.replace(b'version=4.0.0', b'version'))))
   def test_from_remote_malformed_header(self):
-    self.assertRaisesRegexp(OSError, 'Malformed fallback directory header line: /\\* version \\*/', stem.directory.Fallback.from_remote)
+    self.assertRaisesRegex(OSError, 'Malformed fallback directory header line: /\\* version \\*/', stem.directory.Fallback.from_remote)
 
   def test_from_remote_malformed(self):
     test_values = {
@@ -121,7 +121,7 @@ class TestFallback(unittest.TestCase):
 
     for entry, expected in test_values.items():
       with patch('urllib.request.urlopen', Mock(return_value = io.BytesIO(entry))):
-        self.assertRaisesRegexp(OSError, re.escape(expected), stem.directory.Fallback.from_remote)
+        self.assertRaisesRegex(OSError, re.escape(expected), stem.directory.Fallback.from_remote)
 
   def test_persistence(self):
     expected = {

--- a/test/unit/response/add_onion.py
+++ b/test/unit/response/add_onion.py
@@ -89,7 +89,7 @@ class TestAddOnionResponse(unittest.TestCase):
     """
 
     response = ControlMessage.from_str(WRONG_FIRST_KEY, normalize = True)
-    self.assertRaisesRegexp(stem.ProtocolError, 'ADD_ONION response should start with', stem.response.convert, 'ADD_ONION', response)
+    self.assertRaisesRegex(stem.ProtocolError, 'ADD_ONION response should start with', stem.response.convert, 'ADD_ONION', response)
 
   def test_no_key_type(self):
     """
@@ -97,4 +97,4 @@ class TestAddOnionResponse(unittest.TestCase):
     """
 
     response = ControlMessage.from_str(MISSING_KEY_TYPE, normalize = True)
-    self.assertRaisesRegexp(stem.ProtocolError, 'ADD_ONION PrivateKey lines should be of the form', stem.response.convert, 'ADD_ONION', response)
+    self.assertRaisesRegex(stem.ProtocolError, 'ADD_ONION PrivateKey lines should be of the form', stem.response.convert, 'ADD_ONION', response)

--- a/test/unit/util/connection.py
+++ b/test/unit/util/connection.py
@@ -187,12 +187,12 @@ class TestConnection(unittest.TestCase):
   def test_download_retries(self, urlopen_mock):
     urlopen_mock.side_effect = urllib.request.URLError('boom')
 
-    self.assertRaisesRegexp(OSError, 'boom', stem.util.connection.download, URL)
+    self.assertRaisesRegex(OSError, 'boom', stem.util.connection.download, URL)
     self.assertEqual(1, urlopen_mock.call_count)
 
     urlopen_mock.reset_mock()
 
-    self.assertRaisesRegexp(OSError, 'boom', stem.util.connection.download, URL, retries = 4)
+    self.assertRaisesRegex(OSError, 'boom', stem.util.connection.download, URL, retries = 4)
     self.assertEqual(5, urlopen_mock.call_count)
 
   @patch('os.access')

--- a/test/unit/version.py
+++ b/test/unit/version.py
@@ -58,7 +58,7 @@ class TestVersion(unittest.TestCase):
     Tor version output that doesn't include a version within it.
     """
 
-    self.assertRaisesRegexp(OSError, "'tor_unit --version' didn't provide a parseable version", stem.version.get_system_tor_version, 'tor_unit')
+    self.assertRaisesRegex(OSError, "'tor_unit --version' didn't provide a parseable version", stem.version.get_system_tor_version, 'tor_unit')
 
   @patch('stem.util.system.call', Mock(return_value = MALFORMED_TOR_VERSION.splitlines()))
   @patch.dict(stem.version.VERSION_CACHE)


### PR DESCRIPTION
This replaces the deprecated (in python 3) `unittest.TestCase` method `assertRaisesRegexp()`, with `assertRaisesRegex()`.